### PR TITLE
Re-land #17's review fixes, which PR #18's merge missed

### DIFF
--- a/research/cross_system_replication/qdrant_docker_harness.py
+++ b/research/cross_system_replication/qdrant_docker_harness.py
@@ -167,7 +167,16 @@ def build_kill_schedule(condition: str, node_names: list, n_kills: int,
         targets = list(node_names[:n_kills])
     else:
         gap = SHORT_GAP_S if condition == "short-gap-same-node" else LONG_GAP_S
-        targets = [target_node or node_names[0]] * n_kills
+        chosen = target_node or node_names[0]
+        if chosen not in node_names:
+            # Same reason the window check raises here rather than at run time:
+            # a typo'd node name would otherwise build a plausible-looking
+            # schedule, print it, and only fail on containers[name] after the
+            # cluster is up, the corpus written and the pre-chaos window spent.
+            raise ValueError(
+                f"--kill-target-node {chosen!r} is not one of this cluster's "
+                f"nodes: {node_names}")
+        targets = [chosen] * n_kills
 
     schedule, at = [], 0.0
     for i in range(n_kills):

--- a/research/qdrant_kill_scheduler/SPEC.md
+++ b/research/qdrant_kill_scheduler/SPEC.md
@@ -256,3 +256,43 @@ Deliberately *not* done: compensating for the latency by padding requested gaps.
 It varies 3.08-3.58s, so padding would leave residual error while making runs
 look exact - trading a visible, recorded bias for a hidden one. Recording beats
 correcting here.
+
+## Addendum: review round 1 (2026-09-02)
+
+The reviewer recomputed every figure in the validation addendum from
+`results/*/events.json` directly, without using this branch's own checker; all
+reproduced exactly (drift mean -3.24s / worst -3.76s, realized gaps 1.529 and
+2.173 / 37.10 and 36.24, latency +3.08 to +3.58s, targeting 1/1/3). Two defects
+found, both accepted and fixed:
+
+1. **`check_realized_schedule.py` mirrored `FIXED_DOWN_S = 4.5` off the
+   harness.** Change the harness constant and the checker would keep computing
+   latency against 4.5 -- no error, just a quietly wrong number. Fixed by
+   deleting the constant and reading each event's own recorded `down_for_s`,
+   which every event already carried. The derivation is now self-describing from
+   the artifact and stays correct for runs made under any future down-time.
+   Recomputed output after the change is identical, as it must be.
+2. **`build_kill_schedule` did not validate `--kill-target-node`.** A typo'd
+   name built a plausible schedule, printed it, and then died on
+   `containers[name]` at the first kill -- after the cluster was up, the corpus
+   written and the pre-chaos window spent. It now raises at build time, naming
+   the valid nodes, which is the rule the function already applied to infeasible
+   windows and wrong kill counts. Three checks added (27 total).
+
+Both defects were the same shape: a value that could silently disagree with
+reality, in a tool built to catch values that silently disagree with reality.
+The mirrored constant is the sharper of the two, since it would have degraded a
+*measurement* rather than crashed a run.
+
+Two things the reviewer recorded as non-defects, kept here because they bound
+what #9 can use this for:
+
+- **`spread`'s spacing is validated through offsets, not gaps.**
+  `realized_gap_s` is per-node and therefore `None` for every `spread` kill by
+  construction, so the n=4 drift statistic comes entirely from the two same-node
+  conditions. Spread's cadence is confirmed (offsets tracked to +0.15s), but no
+  per-node gap figure for `spread` exists or can be back-derived from these runs.
+- **The latency figure is one host, one Docker daemon, one image, three runs.**
+  #9 does not need it to be universal, since it defines conditions on realized
+  spacing recorded per run -- but nothing should later cite ~3.3s as a property
+  of Qdrant.

--- a/research/qdrant_kill_scheduler/check_realized_schedule.py
+++ b/research/qdrant_kill_scheduler/check_realized_schedule.py
@@ -32,10 +32,6 @@ import os
 # conditions could be confused for each other.
 DRIFT_TOLERANCE_S = 2.0
 
-# chaos_loop_scheduled's fixed down-time, mirrored here so realized restart
-# latency can be derived from an events.json alone.
-FIXED_DOWN_S = 4.5
-
 
 def check_run(run_dir):
     events = json.load(open(os.path.join(run_dir, "events.json")))
@@ -58,6 +54,7 @@ def check_run(run_dir):
             "at_drift": at_drift,
             "req_gap": e["requested_gap_s"], "real_gap": e["realized_gap_s"],
             "gap_drift": gap_drift,
+            "down_for": e.get("down_for_s"),
             "killed_while_down": e.get("killed_while_down"),
             "alive_after_restart": e.get("alive_after_restart"),
         })
@@ -116,14 +113,21 @@ def main():
         # actually restarted the container, so the node comes back LATER than
         # kill+down_for implies, and that lateness is subtracted from the gap.
         # Reported because #9 needs the number, not just the fact.
+        #
+        # down_for is read from each event rather than from a constant mirrored
+        # off the harness. A mirrored constant would keep computing against a
+        # stale value if the harness's changed -- no error, just a quietly wrong
+        # latency, which is the exact failure class this tool exists to catch.
         lat = []
         by_seq = {w["seq"]: w for w in r["rows"]}
         for w in r["rows"]:
             prev = by_seq.get(w["seq"] - 1)
             if prev is None or w["real_gap"] is None:
                 continue
+            if prev["down_for"] is None:
+                continue
             restart_at = w["real_at"] - w["real_gap"]
-            lat.append(restart_at - (prev["real_at"] + FIXED_DOWN_S))
+            lat.append(restart_at - (prev["real_at"] + prev["down_for"]))
         if lat:
             print(f"  implied restart latency (docker start -> node back): "
                   f"{min(lat):+.2f} to {max(lat):+.2f}s  "

--- a/research/qdrant_kill_scheduler/test_kill_schedule.py
+++ b/research/qdrant_kill_scheduler/test_kill_schedule.py
@@ -111,6 +111,17 @@ check("infeasible window does NOT shorten the gap (the independent variable)",
              "do not shorten the gap"))
 check("spread with more kills than nodes raises",
       raises(lambda: dh.build_kill_schedule("spread", NODES, 5, 300.0), "distinct node"))
+check("a target node not in the cluster raises at build time, not at run time",
+      raises(lambda: dh.build_kill_schedule("short-gap-same-node", NODES, 3,
+                                            300.0, target_node="rrd-qdrant-nodeX"),
+             "not one of this cluster"))
+check("the error names the valid nodes",
+      raises(lambda: dh.build_kill_schedule("short-gap-same-node", NODES, 3,
+                                            300.0, target_node="typo"),
+             NODES[0]))
+check("a valid explicit target node is accepted",
+      dh.build_kill_schedule("short-gap-same-node", NODES, 3, 300.0,
+                             target_node=NODES[2])[0]["target"] == NODES[2])
 check("unknown condition raises", raises(
     lambda: dh.build_kill_schedule("no-such-condition", NODES, 3, 300.0), "unknown condition"))
 check("n_kills < 2 raises", raises(


### PR DESCRIPTION
Re-lands the review-round-1 fixes for #17, which **did not reach `main`** when PR #18 merged.

## What happened

PR #18's merge captured commit `a6c2667` (the live-cluster validation), not `0eed9a4` (the two fixes from review round 1). GitHub's PR API was serving a stale `headRefOid` at that moment — noticed and noted in-session, when `gh pr view` reported `head=a6c2667` while both local and `origin` were at `0eed9a4` — and the merge went in against the older commit.

No content was lost: `0eed9a4` is intact on `method/qdrant-kill-scheduler`, and this branch cherry-picks it onto current `main`. Nothing here is new work and nothing is rewritten.

## Verified on `main` before opening this

- `check_realized_schedule.py` still contains the mirrored `FIXED_DOWN_S` (2 occurrences).
- `qdrant_docker_harness.py` has no `--kill-target-node` validation (0 occurrences of the error text).

Both are the defects review round 1 called blocking. After the cherry-pick: 0 and 1 respectively, and `test_kill_schedule.py` passes 27/27.

## What the fixes are

Unchanged from `0eed9a4` and already reviewed on #18 — restated so this PR stands alone:

1. **`check_realized_schedule.py` mirrored `FIXED_DOWN_S = 4.5` off the harness.** Change the harness constant and the checker keeps computing restart latency against 4.5: no error, no warning, a quietly wrong measurement. The constant is deleted; each event's own recorded `down_for_s` is used instead, so the derivation is self-describing from the artifact and stays correct under any future down-time. Recomputed output is identical, as it must be.
2. **`build_kill_schedule` didn't validate `--kill-target-node`.** A typo built a plausible schedule, printed it, then died on `containers[name]` at the first kill — after the cluster was up, the corpus written and the pre-chaos window spent. It now raises at build time naming the valid nodes, matching the rule the function already applied to infeasible windows and bad kill counts.

Tests 24 → 27. `SPEC.md` gains the review-round-1 addendum, including the reviewer's two non-defect notes bounding what #9 may claim: `spread` has no per-node gap figure by construction, and the +3.08–3.58s restart latency is this host's number, not a property of Qdrant.

## Why this matters beyond the two fixes

Defect 1 would have degraded a *measurement* rather than crashed a run — and #9's sweep is the thing that would have consumed it. Merging the sweep's instrument without it is exactly the case for catching this now rather than after hours of compute.

Worth noting as a process observation: the pipeline has no check that what got merged is what was reviewed. Every role here re-derives state from GitHub, and GitHub was briefly wrong. A post-merge verification step — does `main` contain the reviewed head? — would have caught this immediately rather than by chance during a status check.

## Self-assessed decision

**MERGE.** No new content; a cherry-pick of a commit already reviewed on #18, verified to restore both fixes and keep 27/27 checks passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bPTygJN8dEASLXuykwamX
