### PR TITLE
Enforce the research index against the tree in CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,6 +30,10 @@ Closes #<issue number>
 
 (Yes/no, and what's missing if not.)
 
+## If this adds a `research/<name>/` directory, is it in the experiment index?
+
+(`research/README.md`'s table. CI enforces that the directory is *named*; it cannot check that the row's description is true, which is the part a reviewer has to read. A row saying "Not started" for finished work passes CI.)
+
 ## Did the implementation introduce any unintended changes elsewhere?
 
 (Check: existing metrics, datasets, seeds, baseline configurations, other branches' conclusions — see `research/GIT_WORKFLOW.md`'s isolation rule.)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,20 @@ on:
     branches: [main]
 
 jobs:
+  research-index:
+    # Fast, no build: a docs-only PR should not wait on a C++ toolchain to be
+    # told its new research directory is missing from the experiment index.
+    # See issue #22 -- the index drifted three times in one session and was
+    # corrected by hand each time, which lasts until the next merge.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: research/README.md index matches the tree
+        run: python3 research/check_index.py
+
   build-and-test:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/research/AGENT_PIPELINE.md
+++ b/research/AGENT_PIPELINE.md
@@ -105,6 +105,13 @@ experiment. Update `SPEC.md`'s Results/Interpretation/Decision sections once
 there's something to put there — the issue and `SPEC.md` are the same
 content at every stage, not just at the start.
 
+**If the branch adds a `research/<name>/` directory,** add its row to
+`research/README.md`'s experiment index in the same PR — investigation,
+location, type, status. `research/check_index.py` enforces this in CI and runs
+in seconds locally. It checks only that the directory is *named*: whether the
+row's status is still true is a reviewer's job, since a row reading "Not
+started" for finished work passes the check and was a real defect (#15).
+
 **Opening the PR:** `.github/PULL_REQUEST_TEMPLATE.md` auto-populates — fill
 in every section honestly, including a self-assessed
 MERGE/ARCHIVE/REVISE/ABANDON/REPRODUCE decision. Label the PR

--- a/research/check_index.py
+++ b/research/check_index.py
@@ -35,8 +35,12 @@ INDEX = os.path.join(HERE, "README.md")
 # someone makes on purpose, and it shows up in review as one.
 EXEMPT = {
     "__pycache__",
-    "proto",  # generated gRPC stubs, vendored under an experiment
 }
+# Only TOP-LEVEL entries of research/ are enumerated, so a vendored directory
+# nested inside an experiment (research/cross_system_replication/proto, say)
+# never reaches this set and must not be listed here -- an inert exemption
+# tells a future reader that a top-level directory exists or might, and would
+# silently exempt one if it were ever created.
 
 
 def research_dirs():

--- a/research/check_index.py
+++ b/research/check_index.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Fail if research/README.md's experiment index has drifted from the tree.
+
+Issue #22. The index is how a reader finds out what exists; when it drifts,
+merged work becomes invisible. That happened three times in one session -- most
+starkly with `qdrant_kill_scheduler/`, which was merged, validated, live tooling
+that the index never mentioned -- and each time it was corrected by hand, which
+lasts exactly until the next merge.
+
+Two directions are checked, both mechanical:
+
+  1. every research/<dir>/ on disk is named in the index
+  2. every research/<dir>/ the index links to exists on disk
+
+What this deliberately does NOT check is whether a row's *description* is
+accurate. A row reading "Not started" for finished work -- the actual #15 defect
+-- passes this check, because judging a description needs judgement and cannot
+be mechanised. The honest claim is narrow: a directory becomes impossible to
+omit, not impossible to describe wrongly.
+
+Usage:
+    python research/check_index.py           # exit 1 on drift
+    python research/check_index.py --list    # show what was found, always exit 0
+"""
+import argparse
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+INDEX = os.path.join(HERE, "README.md")
+
+# Directories that are not experiments and are not expected in the index.
+# Kept explicit rather than pattern-matched: adding a name here is a decision
+# someone makes on purpose, and it shows up in review as one.
+EXEMPT = {
+    "__pycache__",
+    "proto",  # generated gRPC stubs, vendored under an experiment
+}
+
+
+def research_dirs():
+    out = set()
+    for name in sorted(os.listdir(HERE)):
+        path = os.path.join(HERE, name)
+        if not os.path.isdir(path) or name in EXEMPT or name.startswith("."):
+            continue
+        out.add(name)
+    return out
+
+
+def mentioned_dirs(text):
+    """Every directory name the index refers to, matched loosely.
+
+    Used only for the "exists but is not indexed" direction, where
+    over-matching is the safe way to err: a stray match can only make the
+    checker more forgiving about a directory being mentioned, never invent a
+    failure.
+    """
+    found = set()
+    for m in re.findall(r'\]\(([A-Za-z0-9_./-]+)/\)', text):
+        found.add(m.strip("./").split("/")[0])
+    for m in re.findall(r'`([A-Za-z0-9_-]+)/`', text):
+        found.add(m)
+    for m in re.findall(r'`([A-Za-z0-9_-]+)/[A-Za-z0-9_.-]+`', text):
+        found.add(m)
+    return found
+
+
+def linked_dirs(text):
+    """Directories the index actually LINKS to with a relative path.
+
+    Used for the "index names something that does not exist" direction, which
+    has to be strict. The loose matcher above also picks up branch names in
+    prose -- `experiment/qdrant-kill-spacing` is a git branch, not a directory
+    -- and flagging those as missing directories would be a false alarm, which
+    is worse than no check at all: a checker that cries wolf gets switched off.
+    Only a relative markdown link is a promise that a path exists.
+    """
+    found = set()
+    for m in re.findall(r'\]\((?!https?:)([A-Za-z0-9_./-]+)/\)', text):
+        part = m.strip("./").split("/")[0]
+        if part not in ("..", "."):
+            found.add(part)
+    return found
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--list", action="store_true",
+                    help="report and exit 0 regardless of drift")
+    args = ap.parse_args()
+
+    if not os.path.exists(INDEX):
+        print(f"FAIL: {INDEX} does not exist")
+        return 1
+    text = open(INDEX, encoding="utf-8").read()
+
+    on_disk = research_dirs()
+    named = mentioned_dirs(text)
+    linked = linked_dirs(text)
+
+    missing = sorted(on_disk - named)            # exists, never mentioned
+    dangling = sorted(linked - on_disk - EXEMPT)  # linked to, does not exist
+
+    print(f"research/ directories on disk : {len(on_disk)}")
+    for d in sorted(on_disk):
+        print(f"    {'ok ' if d in named else 'MISSING FROM INDEX'} {d}")
+
+    ok = True
+    if missing:
+        ok = False
+        print("\nFAIL: these directories exist but the experiment index in "
+              "research/README.md never names them:")
+        for d in missing:
+            print(f"    research/{d}/")
+        print("\n  A reader following the index cannot find them. Add a row to "
+              "the\n  experiment index -- investigation, location, type, status.")
+    if dangling:
+        ok = False
+        print("\nFAIL: the index names these, but they do not exist:")
+        for d in dangling:
+            print(f"    research/{d}/")
+        print("\n  Either the directory was moved and the row was not updated, "
+              "or the\n  row describes something that was never committed.")
+
+    if ok:
+        print("\nOK: index and tree agree.")
+    return 0 if (ok or args.list) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #22

## What question did this branch answer?

Not a research question. `research/README.md`'s experiment index named **3 of the 7** directories that existed — `qdrant_kill_scheduler/` among them, merged and validated live tooling that a reader following the index could not find at all.

It was corrected by hand twice in one session (#15, then again after #18 merged). That is the definition of a fix that does not hold: the correction lasts exactly until the next merge.

## What was the hypothesis?

None empirical. The design claim, stated in #22 before any code: both directions of index/tree agreement are checkable from the repository alone with **no judgement**, and that is what makes this enforceable rather than a convention. Conventions were what already existed implicitly, and they produced three hand-fixes in one day.

## What evidence was collected?

The checker was verified to **fail**, not merely to pass on a clean tree — a checker nobody has watched fail is not a checker:

| case | expected | got |
|---|---|---|
| clean tree | exit 0 | ✅ `OK: index and tree agree.` |
| new unindexed directory (`research/fake_experiment_tmp/`) | exit 1 | ✅ names it under "exist but the index never names them" |
| dangling index link (`deleted_thing/`) | exit 1 | ✅ names it under "index names these, but they do not exist" |
| tree restored | exit 0 | ✅ |

`ci.yml` parses (`yaml.safe_load`).

## What does the result actually establish?

That a `research/<name>/` directory can no longer be merged without appearing in the index, and an index row can no longer link to a path that does not exist.

Three implementation choices worth arguing with:

1. **Two matchers, not one.** "Exists but unindexed" matches loosely, because over-matching can only make the checker *more forgiving* — it can never invent a failure. "Indexed but missing" matches only relative markdown links, because the loose matcher also picks up git branch names in prose (`experiment/qdrant-kill-spacing` is a branch, not a directory) and would have reported a false failure. A checker that cries wolf gets switched off, which is worse than no checker.
2. **Its own CI job.** A docs-only PR should not wait on a C++ toolchain to learn its index row is missing. Runs in seconds, no build, no submodules.
3. **An explicit `EXEMPT` set** rather than pattern-matching what "looks like" an experiment. Adding a name to it is a decision someone makes deliberately and that shows up in review as one.

## What does it explicitly NOT establish?

**That the index is now accurate.** This is the important limit and it is written into the script's own docstring, the PR template and the implementer instructions rather than left implied.

The check enforces that a directory is *named*. It cannot check that a row's description is *true*. A row reading "Not started" for finished work — which is the actual #15 defect, the one that started this whole thread — **passes this check**. Judging a description needs judgement and cannot be mechanised.

So the honest claim is narrow: a directory becomes impossible to omit, not impossible to describe wrongly. The second half stays a reviewer's job, and is now written down as one instead of assumed.

## What confounds remain?

The regexes match today's index format — markdown links and inline-code paths. If the table is rewritten in a substantially different style, the loose matcher could silently stop recognising mentions and the check would start failing on directories that *are* indexed. That failure direction is the safe one (a false alarm, not a false pass), but it would need the matcher updated.

## What assumptions were made?

That every `research/<dir>/` deserves an index row unless deliberately exempted. `proto/` (vendored gRPC stubs) and `__pycache__` are exempt today.

## Could another researcher reproduce this?

`python research/check_index.py` — one command, no dependencies beyond the standard library, and the three test cases above are reproducible by creating a directory or editing a link.

## Did the implementation introduce any unintended changes elsewhere?

No experiment, metric, dataset or result is touched. Four files: the new checker, a CI job, a PR-template question, and a paragraph in the implementer role's instructions.

The CI addition is additive — `build-and-test` and `docker` are unchanged, and the new job runs alongside them.

## Does this change the research thesis in the top-level README.md?

No.

## Implementer's self-assessed decision

**MERGE.** Against the nine criteria: relevance (the index is how anyone finds the research; three hand-fixes in a session is evidence the convention does not hold); correctness (verified to fail on both drift directions, not just to pass); experimental validity (n/a); reproducibility (one command, stdlib only); documentation (the change *is* documentation enforcement, and its limits are stated in three places); interpretation (the narrow claim is stated explicitly, including that the #15 defect would still pass); integrity (it would have been easy to describe this as "the index can't go stale" and that would be false); integration (four files, additive, no debt); evidence (sufficient for a process check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bPTygJN8dEASLXuykwamX
