### PR TITLE
analysis: re-land the review fix #58's merge dropped (#55)

### DIFF
--- a/research/RELATED_WORK.md
+++ b/research/RELATED_WORK.md
@@ -277,6 +277,14 @@ can diverge." What no source found does:
    the cluster mean of the same runs. The practitioner sources name the metric
    and do not report it.
 
+   Same caution as novelty item 1: the p = 0.31 is a null at n = 5, so it is
+   consistent with dilution rather than proof of it. The claim that averaging
+   hides the effect rests on the concentration evidence — killed node worst in
+   4 of 5 runs, up to 5 points on that replica against ~1.2 on the mean — and
+   should always be stated with it. A reviewer who reads "the mean was a null,
+   therefore averaging hides it" will correctly object that an underpowered null
+   shows nothing, and they would be right about that step of the argument.
+
 **Cite and distinguish, do not claim:** the stratified-recall principle, and the
 observation that replicas drift. Claim the identity argument, the failure
 attribution, and the measurement.
@@ -305,13 +313,23 @@ claims about the same result.
 
 The current ranking, strongest first:
 
-1. **The measurement unit is the finding: replica-level separation with a
-   cluster-level null on the same runs.** On Qdrant, worst-replica
+1. **The measurement unit is the finding: replica-level separation, with the
+   effect demonstrably concentrated on one replica.** On Qdrant, worst-replica
    `index_recall` under chaos is 0.978 vs 0.990 at baseline, every seed
    separated, exact p = 0.0079 — while the **mean over the same six replicas
-   does not separate, p = 0.31**. Both are correct. A monitor that averages is
-   structurally blind to this. See §7 for what bounds that claim, because the
-   general principle is *not* new.
+   does not separate, p = 0.31**.
+
+   **The null is not the evidence, and this must be stated carefully.** At n = 5
+   on a metric with ~1% of headroom, a null is also what low power looks like,
+   so "the mean does not separate" does not by itself establish "averaging
+   destroys the signal." What carries the claim is the **concentration**: the
+   killed node is the worst replica in **4 of 5 runs**, and the loss is ~1.2
+   points on the seed mean against **up to 5 points on that one replica** — a
+   localized effect diluted sixfold, which is a mechanism for why a mean would
+   hide it rather than merely a failure to reject. Claim the conjunction; the
+   cluster-level null is *consistent with* dilution, not proof of it.
+
+   See §7 for what bounds this, because the general principle is *not* new.
 2. **The three-way decomposition** — `index_recall` (graph quality, data held
    constant) vs `completeness` (data content, no search) vs `e2e_recall` (client
    experience). Vendor blogs gesture at "index quality vs retrieval quality";


### PR DESCRIPTION
Re-lands the review fix that #58's merge dropped. Found by the pipeline's post-merge verification (`AGENT_PIPELINE.md` query 0), which is exactly the case it was written for.

## What happened

- #58's round-2 review approved head `e81b34245ac6f1b07895193bd9d5d865e7fc9671`.
- The merge commit `8892309` took `b6104da41140be1037b2fa4de92a37c139e7bd32` instead.
- `e81b342` is a *child* of `b6104da`, and lives only on `origin/analysis/related-work-refresh`.

The timestamps say why: the merge completed at 09:27:40Z; `e81b342` was pushed at 09:29:13Z, about 93 seconds later. The round-1 fix was written after the human had already merged, and the round-2 MERGE was given on a head that was never merged. Nobody did anything wrong at the console — the ordering was just unlucky, and query 0 exists because nothing else in the pipeline would have caught it.

## What `main` was missing

The whole round-1 fix: the caution on novelty item 1 and the §7 paragraph stating that the cluster-level null (p = 0.31, n = 5) is *consistent with* dilution rather than proof of it, and that the claim rests on the concentration evidence — the killed node worst in 4 of 5 runs, up to 5 points on that replica against ~1.2 on the seed mean — plus §7's concession that a reviewer objecting "an underpowered null shows nothing" would be right about that step.

`git show origin/main:research/RELATED_WORK.md | grep -c 'consistent with dilution'` returned 0 before this branch.

So `main` was carrying the *stronger* wording that review round 1 had found overstated. That is the wrong direction for a document whose whole job is to keep this project's positioning inside its evidence.

## This PR

`e81b342` cherry-picked onto `main` unchanged — `36f7f17`, one file, 23 insertions, 5 deletions, no content edits of my own. Verified:

- `check_research.py` — OK, no mechanical defects
- `check_index.py` — index and tree agree
- diff is one file, no deletions, nothing under `results*/`

## Self-assessed decision

**MERGE.** It is a verbatim cherry-pick of an already-approved commit; the review that approved it is #58's round 2. Nothing new is being asserted here.

Closes nothing — #55 is already closed. It has been relabelled `stage:changes-requested` alongside #58 to record that #58's merge did not deliver what was approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bPTygJN8dEASLXuykwamX
